### PR TITLE
Simplified the elastic-start-local folder and added docker container check

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ as follows (NOTE: the script has not yet been published on elastic.co):
 curl -fsSL https://elastic.co/start-local | sh
 ```
 
-The script will create a n `elastic-start-local` folder with two files:
+The script will create the`elastic-start-local` folder with two files:
 `docker-compose.yml` and `.env`. The first `docker-compose.yml` is a standard
 docker file containing the configurations for Elasticsearch and Kibana services.
 The second file `.env` contains all the settings, like the Elasticsearch password.

--- a/start-local.sh
+++ b/start-local.sh
@@ -35,13 +35,20 @@ echo 'Note: do not use this script in a production environment'
 echo '--------------------------------------------------------'
 
 # Version
-version="0.1.1"
+version="0.2.0"
 
+# Folder name for the installation
+installation_folder="elastic-start-local"
+# API key name for Elasticseach
+api_key_name="elastic-start-local"
 # Name of the error log
 error_log="error-start-local.log"
-
 # Minimum version for docker-compose
 min_docker_compose="1.29.0"
+# Elasticsearch container name
+elasticsearch_container_name="es-local-dev"
+# Kibana container name
+kibana_container_name="kibana-local-dev"
 
 # Trap ctrl-c
 trap ctrl_c INT
@@ -184,6 +191,20 @@ create_api_key() {
   fi
 }
 
+# Check if a docker container is runnning
+check_container_running() {
+    local container_name=$1
+    local containers=$(docker ps --format '{{.Names}}')
+    if $(echo "$containers" | grep -q "^${container_name}$"); then
+      echo "The docker container '$container_name' is already running!"
+      echo "You can have only one running at time."
+      echo "To stop the container run the following command:"
+      echo
+      echo "docker stop $container_name"
+      exit 1
+    fi
+}
+
 # Check the requirements
 if ! available "curl"; then
   echo "Error: curl command is required"
@@ -234,14 +255,21 @@ else
 fi
 set -e
 
-# Create the elastic-start-local folder
-folder_name="elastic-start-local"
-folder=$folder_name
-count=1
-while [ -d "$folder" ]; do
-  folder="${folder_name}-${count}"
-  count=$((count+1))
-done
+# Check if elastic-start-local exists
+folder=$installation_folder
+if [ -d "$folder" ]; then
+  echo "It seems you have already a start-local in the directory $folder."
+  echo "I cannot proceed unless you remove it or move to another folder."
+  echo "Before removing the folder remember to delete the docker services."
+  echo "You can use the following commands (data will be destroyed):"
+  echo "cd $folder"
+  echo $docker_clean
+  exit 1
+fi
+
+# Check for docker containers running
+check_container_running "$elasticsearch_container_name"
+check_container_running "$kibana_container_name"
 
 mkdir $folder
 cd $folder
@@ -256,13 +284,12 @@ kibana_encryption_key="$(random_password 32)"
 # Create the .env file
 cat > .env <<- EOM
 ES_LOCAL_VERSION=$es_version
-ES_LOCAL_CONTAINER_NAME=es-local-dev
-ES_LOCAL_DOCKER_NETWORK=elastic-net
+ES_LOCAL_CONTAINER_NAME=$elasticsearch_container_name
 ES_LOCAL_PASSWORD=$es_password
 ES_LOCAL_PORT=9200
 ES_LOCAL_HEAP_INIT=128m
 ES_LOCAL_HEAP_MAX=2g
-KIBANA_LOCAL_CONTAINER_NAME=kibana-local-dev
+KIBANA_LOCAL_CONTAINER_NAME=$kibana_container_name
 KIBANA_LOCAL_PORT=5601
 KIBANA_LOCAL_PASSWORD=$kibana_password
 KIBANA_ENCRYPTION_KEY=$kibana_encryption_key
@@ -364,7 +391,7 @@ fi
 set -e
 
 # Create an API key for Elasticsearch
-api_key=$(create_api_key $es_password $folder_name)
+api_key=$(create_api_key $es_password $api_key_name)
 if [ -n "$api_key" ]; then
   echo "ES_LOCAL_API_KEY=${api_key}" >> .env
 fi


### PR DESCRIPTION
This PR simplifies the `elastic-start-local` folder removing the incremental name if the folder already exists. In this case, the script emits an error message:
```
It seems you have already a start-local in the directory $folder.
I cannot proceed unless you remove it or move to another folder.
Before removing the folder remember to delete the docker services.
You can use the following commands (data will be destroyed):
cd $folder
docker compose rm -fsv
```
This PR adds also the check for the docker container, if `es-local-dev` or `kibana-local-dev` are running. In this case the error message is (eg. for `es-local-dev` container):
```
The docker container 'es-local-dev' is already running!
You can have only one running at time.
To stop the container run the following command:
docker stop es-local-dev
```