### PR TITLE
Add directory check.

### DIFF
--- a/start-local.sh
+++ b/start-local.sh
@@ -346,14 +346,7 @@ cat > uninstall.sh <<-'EOM'
 # More information: https://github.com/elastic/start-local
 set -eu
 
-check_directory() {
-    current_dir=$(basename "$PWD" 2>/dev/null)
-    if [ "$current_dir" != "elastic-start-local" ]; then
-      echo "Error: You are not in the elastic-start-local directory."
-      echo "Please navigate to the correct directory and try again."
-      exit 1
-    fi
-}
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 ask_confirmation() {
     echo "Do you want to continue? (yes/no)"
@@ -372,8 +365,7 @@ ask_confirmation() {
     esac
 }
 
-check_directory
-
+cd ${SCRIPT_DIR}
 if [ ! -e "docker-compose.yml" ]; then
   echo "Error: I cannot find the docker-compose.yml file"
   echo "I cannot uninstall start-local.

--- a/tests/start_local_uninstall_test.sh
+++ b/tests/start_local_uninstall_test.sh
@@ -24,7 +24,7 @@ DEFAULT_DIR="elastic-start-local"
 # include external scripts
 source "tests/utility.sh"
 
-function set_up_before_script() {
+function set_up() {
     mkdir ${TEST_DIR}
     cd ${TEST_DIR}
     cp ${SCRIPT_DIR}/../start-local.sh ${TEST_DIR}
@@ -33,7 +33,7 @@ function set_up_before_script() {
     cd ${CURRENT_DIR}
 }
 
-function tear_down_after_script() {
+function tear_down() {
     cd ${TEST_DIR}/${DEFAULT_DIR}
     docker compose rm -fsv
     docker compose down -v
@@ -42,7 +42,16 @@ function tear_down_after_script() {
     cd ${CURRENT_DIR}
 }
 
-function test_uninstall() {
+function test_uninstall_outside_installation_folder() {
+    cd ${TEST_DIR}
+    yes | ./${DEFAULT_DIR}/uninstall.sh
+    assert_exit_code "1" "$(check_docker_service_running es-local-dev)"
+    assert_exit_code "1" "$(check_docker_service_running kibana-local-dev)"
+    assert_exit_code "1" "$(check_docker_service_running kibana_settings)"
+    assert_is_directory_empty ${TEST_DIR}/${DEFAULT_DIR}
+}
+
+function test_uninstall_in_installation_folder() {
     cd ${TEST_DIR}/${DEFAULT_DIR}
     yes | ./uninstall.sh
     assert_exit_code "1" "$(check_docker_service_running es-local-dev)"


### PR DESCRIPTION
Hey, it's me again 🤦🏼 

This update introduces a directory validation check to ensure the uninstall script is executed only within the `elastic-start-local` directory. 

If the script is run outside the correct directory, an error message is displayed, and the process is stopped. This enhancement ensures safe execution and prevents unintended deletions. 

You might wonder why I created this PR. Well, I accidentally deleted the wrong `docker-compose.yml` and `.env` files when running `elastic-start-local/uninstall.sh`. Although the documentation is clear, sometimes even the most diligent developers can make mistakes when in a rush. I believe adding this small safeguard could help prevent similar issues for others.