### PR TITLE
Added start and stop scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ curl -fsSL https://elastic.co/start-local | sh
 This script creates an `elastic-start-local` folder containing:
 - `docker-compose.yml`: Docker Compose configuration for Elasticsearch and Kibana
 - `.env`: Environment settings, including the Elasticsearch password
-- `start.sh` and `stop.sh`: The scripts to start and stop Elasticsearch and Kibana
+- `start.sh` and `stop.sh`: Scripts to start and stop Elasticsearch and Kibana
 - `uninstall.sh`: The script to uninstall Elasticsearch and Kibana
 
 ### 🌐 Endpoints

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ curl $ES_LOCAL_URL -H "Authorization: ApiKey ${ES_LOCAL_API_KEY}"
 
 You can use the `start` and `stop` commands available in the `elastic-start-local` folder.
 
-If you want to **stop** the Docker services of Elasticsearch and Kibana, just use the `stop` command, as follows:
+To **stop** the Elasticsearch and Kibana Docker services, use the `stop` command:
 
 ```bash
 cd elastic-start-local

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ cd elastic-start-local
 ./stop.sh
 ```
 
-If you want to **start** the services, just execute the `start` command, as follows:
+To **start** the Elasticsearch and Kibana Docker services, use the `start` command:
 
 ```bash
 cd elastic-start-local

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ curl -fsSL https://elastic.co/start-local | sh
 This script creates an `elastic-start-local` folder containing:
 - `docker-compose.yml`: Docker Compose configuration for Elasticsearch and Kibana
 - `.env`: Environment settings, including the Elasticsearch password
+- `start.sh` and `stop.sh`: The scripts to start and stop Elasticsearch and Kibana
 - `uninstall.sh`: The script to uninstall Elasticsearch and Kibana
 
 ### 🌐 Endpoints
@@ -59,18 +60,25 @@ source .env
 curl $ES_LOCAL_URL -H "Authorization: ApiKey ${ES_LOCAL_API_KEY}"
 ```
 
-## 🐳 Managing Docker services
+## 🐳 Start and stop the services
 
-Go to the `elastic-start-local` folder to manage services using [Docker Compose](https://docs.docker.com/reference/cli/docker/compose/).
+You can use the `start` and `stop` commands available in the `elastic-start-local` folder.
 
-### Common commands
+If you want to **stop** the Docker services of Elasticsearch and Kibana, just use the `stop` command, as follows:
 
-- Restart services: `docker compose up --wait`
-- Stop services: `docker compose stop`
+```bash
+cd elastic-start-local
+./stop.sh
+```
 
-> [!NOTE]
-> For older versions of Docker Compose:
-> - Start services: `docker-compose up -d`
+If you want to **start** the services, just execute the `start` command, as follows:
+
+```bash
+cd elastic-start-local
+./start.sh
+```
+
+[Docker Compose](https://docs.docker.com/reference/cli/docker/compose/).
 
 ## 🗑️ Uninstallation
 
@@ -106,14 +114,11 @@ ES_LOCAL_API_KEY=df34grtk...==
 ```
 
 > [!IMPORTANT]
-> After changing the `.env` file, restart the services:
+> After changing the `.env` file, restart the services using `stop` and `start`:
 > ```bash
-> docker compose restart
-> ```
-> 
-> Or for older versions:
-> ```bash
-> docker-compose restart
+> cd elastic-start-local
+> ./stop.sh
+> ./start.sh
 > ```
 
 ## 🧪 Testing the installer

--- a/start-local.sh
+++ b/start-local.sh
@@ -532,11 +532,11 @@ EOM
 print_steps() {
   echo "⌛️ Setting up Elasticsearch and Kibana v${es_version}..."
   echo
-  echo "- Created the ${folder} folder"
   echo "- Generated random passwords"
-  echo "- Created a .env file with settings"
-  echo "- Created a docker-compose.yml file"
-  echo "- Created start/stop/uninstall commands"
+  echo "- Created the ${folder} folder containing the files:"
+  echo "  - .env, with settings"
+  echo "  - docker-compose.yml, for Docker services"
+  echo "  - start/stop/uninstall commands"
 }
 
 running_docker_compose() {

--- a/start-local.sh
+++ b/start-local.sh
@@ -338,9 +338,70 @@ KIBANA_ENCRYPTION_KEY=$kibana_encryption_key
 EOM
 }
 
+# Create the start script (start.sh)
+create_start_file() {
+  cat > start.sh <<-'EOM'
+#!/bin/sh
+# Start script for start-local
+# More information: https://github.com/elastic/start-local
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd ${SCRIPT_DIR}
+
+EOM
+  if [ "$need_wait_for_kibana" = true ]; then
+    cat >> start.sh <<-'EOM'
+wait_for_kibana() {
+  local timeout="${1:-60}"
+  echo "- Waiting for Kibana to be ready"
+  echo
+  local start_time="$(date +%s)"
+  until curl -s -I http://localhost:5601 | grep -q 'HTTP/1.1 302 Found'; do
+    elapsed_time="$(($(date +%s) - start_time))"
+    if [ "$elapsed_time" -ge "$timeout" ]; then
+      echo "Error: Kibana timeout of ${timeout} sec"
+      exit 1
+    fi
+    sleep 2
+  done
+}
+
+EOM
+  fi
+  cat >> start.sh <<- EOM
+$docker
+EOM
+  if [ "$need_wait_for_kibana" = true ]; then
+    cat >> start.sh <<-'EOM'
+wait_for_kibana 120
+EOM
+  fi
+  chmod +x start.sh
+}
+
+# Create the stop script (stop.sh)
+create_stop_file() {
+  cat > stop.sh <<-'EOM'
+#!/bin/sh
+# Stop script for start-local
+# More information: https://github.com/elastic/start-local
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd ${SCRIPT_DIR}
+EOM
+
+  cat >> stop.sh <<- EOM
+$docker_stop
+EOM
+  chmod +x stop.sh
+}
+
+# Create the uninstall script (uninstall.sh)
 create_uninstall_file() {
-# Uninstall script
-cat > uninstall.sh <<-'EOM'
+
+  cat > uninstall.sh <<-'EOM'
 #!/bin/sh
 # Uninstall script for start-local
 # More information: https://github.com/elastic/start-local
@@ -379,10 +440,10 @@ echo "All data will be deleted and cannot be recovered."
 if ask_confirmation; then
 EOM
 
-cat >> uninstall.sh <<- EOM
+  cat >> uninstall.sh <<- EOM
   $docker_clean
   $docker_remove_volumes
-  rm docker-compose.yml .env uninstall.sh
+  rm docker-compose.yml .env uninstall.sh start.sh stop.sh
   echo "Start-local successfully removed"
 fi
 EOM
@@ -475,6 +536,7 @@ print_steps() {
   echo "- Generated random passwords"
   echo "- Created a .env file with settings"
   echo "- Created a docker-compose.yml file"
+  echo "- Created start/stop/uninstall commands"
 }
 
 running_docker_compose() {
@@ -540,6 +602,8 @@ main() {
   check_docker_services
   create_installation_folder
   generate_passwords_api_keys
+  create_start_file
+  create_stop_file
   create_uninstall_file
   create_env_file
   create_docker_compose_file

--- a/tests/start_local_start_stop_test.sh
+++ b/tests/start_local_start_stop_test.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+CURRENT_DIR=$(pwd) 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TEST_DIR="${SCRIPT_DIR}/test-start-local"
+DEFAULT_DIR="elastic-start-local"
+
+# include external scripts
+source "tests/utility.sh"
+
+function set_up_before_script() {
+    mkdir ${TEST_DIR}
+    cd ${TEST_DIR}
+    cp ${SCRIPT_DIR}/../start-local.sh ${TEST_DIR}
+    sh ${TEST_DIR}/start-local.sh
+    source ${TEST_DIR}/${DEFAULT_DIR}/.env
+    cd ${CURRENT_DIR}
+}
+
+function tear_down_after_script() {
+    cd ${TEST_DIR}/${DEFAULT_DIR}
+    docker compose rm -fsv
+    docker compose down -v
+    cd ${SCRIPT_DIR}
+    rm -rf ${TEST_DIR}
+    cd ${CURRENT_DIR}
+}
+
+function test_stop() {
+    ${TEST_DIR}/${DEFAULT_DIR}/stop.sh
+
+    assert_exit_code "1" "$(check_docker_service_running es-local-dev)"
+    assert_exit_code "1" "$(check_docker_service_running kibana-local-dev)"
+    assert_exit_code "1" "$(check_docker_service_running kibana_settings)"
+}
+
+function test_start() {
+    ${TEST_DIR}/${DEFAULT_DIR}/start.sh
+
+    assert_exit_code "0" "$(check_docker_service_running es-local-dev)"
+    assert_exit_code "0" "$(check_docker_service_running kibana-local-dev)"
+}


### PR DESCRIPTION
This is a proposal for adding a `start.sh` and `stop.sh` scripts to facilitate the start and the stop of the docker services. This script can be used after the `start-local` installation, e.g. after a reboot. Using these scripts the user do not need to interact with docker commands anymore for start, stop or re-start Elasticsearch and Kibana.