### PR TITLE
Added the license update in start.sh

### DIFF
--- a/start-local.sh
+++ b/start-local.sh
@@ -378,8 +378,9 @@ EOM
   cat >> start.sh <<- EOM
 if [ ! -n "\${ES_LOCAL_LICENSE:-}" ] && [ "\$today" -gt $expire ]; then
   echo "---------------------------------------------------------------------"
-  echo "The trial period has expired, you can continue with the Basic license"
-  echo "or ask to extend the trial for another 30-day using this form:"
+  echo "The one-month trial period has expired. You can continue using the"
+  echo "Free and open Basic license or request to extend the trial for"
+  echo "another 30 days using this form:"
   echo "https://www.elastic.co/trialextension"
   echo "---------------------------------------------------------------------"
   echo "For more info about the license: https://www.elastic.co/subscriptions"

--- a/start-local.sh
+++ b/start-local.sh
@@ -38,7 +38,7 @@ startup() {
   echo
 
   # Version
-  version="0.2.0"
+  version="0.3.0"
 
   # Folder name for the installation
   installation_folder="elastic-start-local"
@@ -339,7 +339,11 @@ EOM
 }
 
 # Create the start script (start.sh)
+# including the license update if trial expired
 create_start_file() {
+  local today=$(date +%s)
+  local expire=$((today + 3600*24*30))
+
   cat > start.sh <<-'EOM'
 #!/bin/sh
 # Start script for start-local
@@ -348,7 +352,8 @@ set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd ${SCRIPT_DIR}
-
+today=$(date +%s)
+. ./.env
 EOM
   if [ "$need_wait_for_kibana" = true ]; then
     cat >> start.sh <<-'EOM'
@@ -369,9 +374,35 @@ wait_for_kibana() {
 
 EOM
   fi
+
   cat >> start.sh <<- EOM
+if [ ! -n "\${ES_LOCAL_LICENSE:-}" ] && [ "\$today" -gt $expire ]; then
+  echo "---------------------------------------------------------------------"
+  echo "The trial period has expired, you can continue with the Basic license"
+  echo "or ask to extend the trial for another 30-day using this form:"
+  echo "https://www.elastic.co/trialextension"
+  echo "---------------------------------------------------------------------"
+  echo "For more info about the license: https://www.elastic.co/subscriptions"
+  echo
+  echo "Updating the license..."
+  $docker elasticsearch >/dev/null 2>&1
+  result=\$(curl -s -X POST "\${ES_LOCAL_URL}/_license/start_basic?acknowledge=true" -H "Authorization: ApiKey \${ES_LOCAL_API_KEY}" -o /dev/null -w '%{http_code}\n')
+  if [ "\$result" = "200" ]; then
+    echo "✅ Basic license successfully installed"
+    echo "ES_LOCAL_LICENSE=basic" >> .env
+  else 
+    echo "Error: I cannot update the license"
+    result=\$(curl -s -X GET "\${ES_LOCAL_URL}" -H "Authorization: ApiKey \${ES_LOCAL_API_KEY}" -o /dev/null -w '%{http_code}\n')
+    if [ "\$result" != "200" ]; then
+      echo "Elasticsearch is not running."
+    fi
+    exit 1
+  fi
+  echo
+fi
 $docker
 EOM
+
   if [ "$need_wait_for_kibana" = true ]; then
     cat >> start.sh <<-'EOM'
 wait_for_kibana 120

--- a/tests/start_local_expire_license_test.sh
+++ b/tests/start_local_expire_license_test.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+CURRENT_DIR=$(pwd) 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TEST_DIR="${SCRIPT_DIR}/test-start-local"
+DEFAULT_DIR="elastic-start-local"
+
+# include external scripts
+source "tests/utility.sh"
+
+function set_up_before_script() {
+    mkdir ${TEST_DIR}
+    cd ${TEST_DIR}
+    cp ${SCRIPT_DIR}/../start-local.sh ${TEST_DIR}
+    sh ${TEST_DIR}/start-local.sh
+    source ${TEST_DIR}/${DEFAULT_DIR}/.env
+    cd ${CURRENT_DIR}
+}
+
+function tear_down_after_script() {
+    cd ${TEST_DIR}/${DEFAULT_DIR}
+    docker compose rm -fsv
+    docker compose down -v
+    cd ${SCRIPT_DIR}
+    rm -rf ${TEST_DIR}
+    cd ${CURRENT_DIR}
+}
+
+function test_start_with_expired_license() {
+    # Check license is trial
+    license=$(get_elasticsearch_license)
+    assert_equals "$license" "trial"
+    
+    # Change the expire dat in start.sh
+    sed -i -E "0,/[0-9]{9}/s/[0-9]{10}/1/" ${TEST_DIR}/${DEFAULT_DIR}/start.sh
+    ${TEST_DIR}/${DEFAULT_DIR}/start.sh
+
+    # Check license is basic
+    license=$(get_elasticsearch_license)
+    assert_equals "$license" "basic"
+}
+
+function get_elasticsearch_license() {
+    local response=$(curl -X GET $ES_LOCAL_URL/_license -H "Authorization: ApiKey ${ES_LOCAL_API_KEY}")
+    echo "$response" | jq -r '.license.type'
+}


### PR DESCRIPTION
This PR adds the license update when the trial expired. To update Elasticsearch we need to execute the [start Basic API](https://www.elastic.co/guide/en/elasticsearch/reference/current/start-basic.html). I added this update in the start.sh generated script. If the license is expired, after 30 days, when running the start.sh script the update is executed. 
Using this approach we will have automatic license update to [Basic free and open](https://www.elastic.co/subscriptions).