### PR TITLE
Removed get_latest_version in favor of a fixed version for ES

### DIFF
--- a/start-local.sh
+++ b/start-local.sh
@@ -180,13 +180,6 @@ random_password() {
   echo $(LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | head -c ${LENGTH})
 }
 
-# Returns the latest Elasticsearch tag version
-get_latest_version() {
-  local tags="$(curl -s "https://api.github.com/repos/elastic/elasticsearch/tags")"
-  local latest="$(echo "$tags" | grep -m 1 '"name"' | grep -Eo '[0-9.]+')"
-  echo $latest
-}
-
 # Create an API key for Elasticsearch
 # parameter 1: the Elasticsearch password
 # parameter 2: name of the API key to generate
@@ -317,7 +310,7 @@ generate_passwords_api_keys() {
   # Generate random passwords
   es_password="$(random_password)"
   kibana_password="$(random_password)"
-  es_version="$(get_latest_version)"
+  es_version="8.15.3"
   kibana_encryption_key="$(random_password 32)"
 }
 


### PR DESCRIPTION
I removed the `get_latest_version()` function in favor of a fixed latest version for Elasticsearch. This should fix all the issue regarding API limit in github, see https://github.com/elastic/start-local/issues/11. 
As cons, this will require to update the start-local script when a new version of Elasticsearch is released.