### PR TITLE
Fixed the 90% disk space limit of ES

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ For a complete list of subscriptions and features, see our [subscriptions page](
 
 ## 💻 System requirements
 
+- 5 GB of available disk space
 - [Docker](https://www.docker.com/)
 - Works on Linux and macOS
 - On Microsoft Windows it works using [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install)

--- a/tests/start_local_expire_license_test.sh
+++ b/tests/start_local_expire_license_test.sh
@@ -47,8 +47,8 @@ function test_start_with_expired_license() {
     license=$(get_elasticsearch_license)
     assert_equals "$license" "trial"
     
-    # Change the expire dat in start.sh
-    sed -i -E "0,/[0-9]{9}/s/[0-9]{10}/1/" ${TEST_DIR}/${DEFAULT_DIR}/start.sh
+    # Change the expire date in start.sh
+    sed -i -E 's/-gt [0-9]+/-gt 1/' ${TEST_DIR}/${DEFAULT_DIR}/start.sh
     ${TEST_DIR}/${DEFAULT_DIR}/start.sh
 
     # Check license is basic


### PR DESCRIPTION
This PR fixes the 90% disk space limit of Elasticsearch (issue #19). The minim required space for installing Elasticsearch and Kibana using start-local is 5 GB (about 3 GB for the two docker images + about 1 GB for store space,  i.e. indices, + 1 GB for the minimum required by Elasticsearch ). The setting used for Elasticsearch are the following:
```
- cluster.routing.allocation.disk.watermark.low=1gb
- cluster.routing.allocation.disk.watermark.high=1gb
- cluster.routing.allocation.disk.watermark.flood_stage=1gb
```
Elasticsearch will continue to operate as long as there is at least 1 GB of free disk space.