### PR TITLE
Added interpolation format using double dollars in docker command

### DIFF
--- a/start-local.sh
+++ b/start-local.sh
@@ -611,9 +611,15 @@ EOM
     command: >
       bash -c '
         echo "Setup the kibana_system password";
-        start_time=$(date +%s);
+        start_time=$$(date +%s);
         timeout=60;
-        until curl -s -u "elastic:${ES_LOCAL_PASSWORD}" -X POST http://elasticsearch:${ES_LOCAL_PORT}/_security/user/kibana_system/_password -d "{\"password\":\"'${KIBANA_LOCAL_PASSWORD}'\"}" -H "Content-Type: application/json" | grep -q "^{}"; do if [ $(($(date +%s) - $$start_time)) -ge $$timeout ]; then echo "Error: Elasticsearch timeout"; exit 1; fi; sleep 2; done;
+        until curl -s -u "elastic:${ES_LOCAL_PASSWORD}" -X POST http://elasticsearch:${ES_LOCAL_PORT}/_security/user/kibana_system/_password -d "{\"password\":\"${KIBANA_LOCAL_PASSWORD}\"}" -H "Content-Type: application/json" | grep -q "^{}"; do
+          if [ $$(($$(date +%s) - $$start_time)) -ge $$timeout ]; then
+            echo "Error: Elasticsearch timeout";
+            exit 1;
+          fi;
+          sleep 2;
+        done;
       '
 
   kibana:


### PR DESCRIPTION
This PR should fix #32 adding the right interpolation format for the `command` section of Docker, using double dollar `$$`. This issue seems affect only version `1.29.x` of docker composer. Thanks @tehlers320 for the insight.