### PR TITLE
Added telemetry for Kibana

### DIFF
--- a/start-local.sh
+++ b/start-local.sh
@@ -77,7 +77,7 @@ startup() {
   echo
 
   # Version
-  version="0.8.1"
+  version="0.9.0"
 
   # Folder name for the installation
   installation_folder="elastic-start-local"
@@ -462,6 +462,7 @@ choose_es_version() {
 create_env_file() {
   # Create the .env file
   cat > .env <<- EOM
+START_LOCAL_VERSION=$version
 ES_LOCAL_VERSION=$es_version
 ES_LOCAL_CONTAINER_NAME=$elasticsearch_container_name
 ES_LOCAL_PASSWORD=$es_password
@@ -630,7 +631,7 @@ EOM
   cat >> uninstall.sh <<- EOM
   $docker_clean
   $docker_remove_volumes
-  rm docker-compose.yml .env uninstall.sh start.sh stop.sh
+  rm -rf docker-compose.yml .env uninstall.sh start.sh stop.sh config/
   echo "Start-local successfully removed"
 fi
 EOM
@@ -722,6 +723,7 @@ if  [ -z "${esonly:-}" ]; then
     container_name: ${KIBANA_LOCAL_CONTAINER_NAME}
     volumes:
       - dev-kibana:/usr/share/kibana/data
+      - ./config/telemetry.yml:/usr/share/kibana/config/telemetry.yml
     ports:
       - 127.0.0.1:${KIBANA_LOCAL_PORT}:5601
     environment:
@@ -754,6 +756,17 @@ if  [ -z "${esonly:-}" ]; then
   dev-kibana:
 EOM
 fi
+
+create_kibana_config
+}
+
+create_kibana_config() {
+  mkdir config
+  # Create telemetry
+  cat > config/telemetry.yml <<- EOM
+start-local:
+  version: ${version}
+EOM
 }
 
 print_steps() {

--- a/tests/basic_test.sh
+++ b/tests/basic_test.sh
@@ -92,6 +92,19 @@ function test_API_key_exists() {
     -H 'Content-Type: application/json' \
     "localhost:9200/_security/api_key" \
     -d "{\"name\":\"${DEFAULT_DIR}\"}" \
-     -o /dev/null \
-    -w '%{http_code}\n' -s    )
+    -o /dev/null \
+    -w '%{http_code}\n' -s)
+}
+
+function test_telemetry_start-local() {
+    result=$(curl -X POST \
+    -u "elastic:${ES_LOCAL_PASSWORD}" \
+    -H "kbn-xsrf: reporting" \
+    -H "Content-Type: application/json" \
+    -H "x-elastic-internal-origin: Kibana" \
+    "http://localhost:5601/internal/telemetry/clusters/_stats?apiVersion=2" \
+    -d "{\"unencrypted\":true,\"refreshCache\":true}" \
+    -s | jq '.[0].stats.stack_stats.kibana.plugins.static_telemetry."start-local".version')
+
+    assert_equals "\"${START_LOCAL_VERSION}\"" "$result"
 }

--- a/tests/utility.sh
+++ b/tests/utility.sh
@@ -54,6 +54,7 @@ function login_kibana() {
     result=$(curl -X POST \
         -H "Content-Type: application/json" \
         -H "kbn-xsrf: reporting" \
+        -H "x-elastic-internal-origin: Kibana" \
         -d '{"providerType":"basic","providerName":"basic","currentURL":"'"$url"'/login?next=%2F","params":{"username":"'"$username"'","password":"'"$password"'"}}' \
         "${url}/internal/security/login" \
         -o /dev/null \


### PR DESCRIPTION
This PR adds the following telemetry for Kibana, generating the `config/telemetry.yml` file.
```yml
start-local:
  version: ${version}
```
where `${version}` is the `START_LOCAL_VERSION` env value, stored in `.env` file.