### PR TITLE
Added the prune of docker images when uninstall

### DIFF
--- a/start-local.sh
+++ b/start-local.sh
@@ -36,7 +36,7 @@ parse_args() {
         shift 2
         ;;
 
-      -esonly)
+      --esonly)
         esonly=true
         shift
         ;;
@@ -77,7 +77,7 @@ startup() {
   echo
 
   # Version
-  version="0.9.0"
+  version="0.9.1"
 
   # Folder name for the installation
   installation_folder="elastic-start-local"
@@ -599,7 +599,7 @@ set -eu
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 ask_confirmation() {
-    echo "Do you want to continue? (yes/no)"
+    echo "Do you confirm? (yes/no)"
     read -r answer
     case "$answer" in
         yes|y|Y|Yes|YES)
@@ -635,6 +635,30 @@ EOM
   rm docker-compose.yml .env uninstall.sh start.sh stop.sh config/telemetry.yml
   if [ -z "\$(ls -A config)" ]; then
     rm -d config
+  fi
+  echo
+  echo "Do you want to remove the following Docker images?"
+  echo "- docker.elastic.co/elasticsearch/elasticsearch:${es_version}"
+EOM
+
+  if  [ -z "${esonly:-}" ]; then
+    cat >> uninstall.sh <<- EOM
+  echo "- docker.elastic.co/kibana/kibana:${es_version}"
+EOM
+  fi
+
+  cat >> uninstall.sh <<- EOM
+  if ask_confirmation; then
+    docker rmi docker.elastic.co/elasticsearch/elasticsearch:${es_version}
+EOM
+
+  if  [ -z "${esonly:-}" ]; then
+    cat >> uninstall.sh <<- EOM
+    docker rmi docker.elastic.co/kibana/kibana:${es_version}
+EOM
+  fi
+
+  cat >> uninstall.sh <<- EOM
   fi
   echo "Start-local successfully removed"
 fi

--- a/tests/basic_test.sh
+++ b/tests/basic_test.sh
@@ -28,13 +28,13 @@ UNINSTALL_FILE="${DEFAULT_DIR}/uninstall.sh"
 source "${CURRENT_DIR}/tests/utility.sh"
 
 function set_up_before_script() {
-    sh "start-local.sh"
+    sh "${CURRENT_DIR}/start-local.sh"
     # shellcheck disable=SC1090
     source "${ENV_PATH}"
 }
 
 function tear_down_after_script() {
-    yes | "${DEFAULT_DIR}/uninstall.sh"
+    printf "yes\nno\n" | "${DEFAULT_DIR}/uninstall.sh"
     rm -rf "${DEFAULT_DIR}"
 }
 

--- a/tests/expire_license_test.sh
+++ b/tests/expire_license_test.sh
@@ -24,13 +24,13 @@ ENV_PATH="${DEFAULT_DIR}/.env"
 source "${CURRENT_DIR}/tests/utility.sh"
 
 function set_up_before_script() {
-    sh "start-local.sh"
+    sh "${CURRENT_DIR}/start-local.sh"
     # shellcheck disable=SC1090
     source "${ENV_PATH}"
 }
 
 function tear_down_after_script() {
-    yes | "${DEFAULT_DIR}/uninstall.sh"
+    printf "yes\nno\n" | "${DEFAULT_DIR}/uninstall.sh"
     rm -rf "${DEFAULT_DIR}"
 }
 

--- a/tests/install_esonly_test.sh
+++ b/tests/install_esonly_test.sh
@@ -25,13 +25,13 @@ UNINSTALL_FILE="${DEFAULT_DIR}/uninstall.sh"
 source "${CURRENT_DIR}/tests/utility.sh"
 
 function set_up_before_script() {
-    sh "start-local.sh" "-esonly"
+    sh "${CURRENT_DIR}/start-local.sh" "-esonly"
     # shellcheck disable=SC1090
     source "${ENV_PATH}"
 }
 
 function tear_down_after_script() {
-    yes | "${UNINSTALL_FILE}"
+    printf "yes\nno\n" | "${UNINSTALL_FILE}"
     rm -rf "${DEFAULT_DIR}"
 }
 

--- a/tests/install_from_curl_test.sh
+++ b/tests/install_from_curl_test.sh
@@ -37,7 +37,7 @@ function set_up_before_script() {
 }
 
 function tear_down_after_script() {
-    yes | "${DEFAULT_DIR}/uninstall.sh"
+    printf "yes\nno\n" | "${DEFAULT_DIR}/uninstall.sh"
     rm -rf "${DEFAULT_DIR}"
     kill -9 "$PHP_SERVER_PID"
     wait "$PHP_SERVER_PID" 2>/dev/null

--- a/tests/install_with_version_test.sh
+++ b/tests/install_with_version_test.sh
@@ -26,13 +26,13 @@ ES_VERSION="8.17.0"
 source "${CURRENT_DIR}/tests/utility.sh"
 
 function set_up_before_script() {
-    sh "start-local.sh" "-v" "${ES_VERSION}"
+    sh "${CURRENT_DIR}/start-local.sh" "-v" "${ES_VERSION}"
     # shellcheck disable=SC1090
     source "${ENV_PATH}"
 }
 
 function tear_down_after_script() {
-    yes | "${UNINSTALL_FILE}"
+    printf "yes\nno\n" | "${UNINSTALL_FILE}"
     rm -rf "${DEFAULT_DIR}"
 }
 

--- a/tests/start_stop_test.sh
+++ b/tests/start_stop_test.sh
@@ -25,13 +25,13 @@ UNINSTALL_FILE="${DEFAULT_DIR}/uninstall.sh"
 source "${CURRENT_DIR}/tests/utility.sh"
 
 function set_up_before_script() {
-    sh "start-local.sh"
+    sh "${CURRENT_DIR}/start-local.sh"
     # shellcheck disable=SC1090
     source "${ENV_PATH}"
 }
 
 function tear_down_after_script() {
-    yes | "${UNINSTALL_FILE}"
+    printf "yes\nno\n" | "${UNINSTALL_FILE}"
     rm -rf "${DEFAULT_DIR}"
 }
 

--- a/tests/uninstall_test.sh
+++ b/tests/uninstall_test.sh
@@ -25,7 +25,7 @@ UNINSTALL_FILE="${DEFAULT_DIR}/uninstall.sh"
 source "${CURRENT_DIR}/tests/utility.sh"
 
 function set_up() {
-    sh "start-local.sh"
+    sh "${CURRENT_DIR}/start-local.sh"
     # shellcheck disable=SC1090
     source "${ENV_PATH}"
 }
@@ -35,18 +35,33 @@ function tear_down() {
 }
 
 function test_uninstall_outside_installation_folder() {
-    yes | "${UNINSTALL_FILE}"
+    printf "yes\nno\n" | "${UNINSTALL_FILE}"
     assert_exit_code "1" "$(check_docker_service_running es-local-dev)"
     assert_exit_code "1" "$(check_docker_service_running kibana-local-dev)"
     assert_exit_code "1" "$(check_docker_service_running kibana_settings)"
     assert_is_directory_empty "${TEST_DIR}/${DEFAULT_DIR}"
+    assert_exit_code "0" "$(check_docker_image_exists docker.elastic.co/elasticsearch/elasticsearch:${ES_LOCAL_VERSION})"
+    assert_exit_code "0" "$(check_docker_image_exists docker.elastic.co/kibana/kibana:${ES_LOCAL_VERSION})"
 }
 
 function test_uninstall_in_installation_folder() {
     cd "${DEFAULT_DIR}" || exit
-    yes | ./uninstall.sh
+    printf "yes\nno\n" | ./uninstall.sh
     assert_exit_code "1" "$(check_docker_service_running es-local-dev)"
     assert_exit_code "1" "$(check_docker_service_running kibana-local-dev)"
     assert_exit_code "1" "$(check_docker_service_running kibana_settings)"
     assert_is_directory_empty "${DEFAULT_DIR}"
+    assert_exit_code "0" "$(check_docker_image_exists docker.elastic.co/elasticsearch/elasticsearch:${ES_LOCAL_VERSION})"
+    assert_exit_code "0" "$(check_docker_image_exists docker.elastic.co/kibana/kibana:${ES_LOCAL_VERSION})"
+}
+
+function test_uninstall_remove_images() {
+    cd "${DEFAULT_DIR}" || exit
+    printf "yes\nyes\n" | ./uninstall.sh
+    assert_exit_code "1" "$(check_docker_service_running es-local-dev)"
+    assert_exit_code "1" "$(check_docker_service_running kibana-local-dev)"
+    assert_exit_code "1" "$(check_docker_service_running kibana_settings)"
+    assert_is_directory_empty "${DEFAULT_DIR}"
+    assert_exit_code "1" "$(check_docker_image_exists docker.elastic.co/elasticsearch/elasticsearch:${ES_LOCAL_VERSION})"
+    assert_exit_code "1" "$(check_docker_image_exists docker.elastic.co/kibana/kibana:${ES_LOCAL_VERSION})"
 }

--- a/tests/utility.sh
+++ b/tests/utility.sh
@@ -80,3 +80,13 @@ check_docker_service_running() {
     return 1 # false
   fi
 }
+
+# Check if a docker image exists
+check_docker_image_exists() {
+  local image_name=$1
+  if docker image inspect "$image_name" > /dev/null 2>&1; then
+    return 0 # true
+  else
+    return 1 # false
+  fi
+}


### PR DESCRIPTION
This PR implements the #56 proposal. It adds this questions when running `uninstall.sh` script:
```
Do you want to remove the following Docker images?
- docker.elastic.co/elasticsearch/elasticsearch:9.0.2
- docker.elastic.co/kibana/kibana:9.0.2
Do you confirm? (yes/no)
```
If confirm is `yes` the script execute the following commands:
```
docker rmi docker.elastic.co/elasticsearch/elasticsearch:9.0.2
docker rmi docker.elastic.co/kibana/kibana:9.0.2
```
The docker disk images of Elasticsearch and Kibana 9.0.2 is about 2.6 GB.