### PR TITLE
Fix for docker ARM64

### DIFF
--- a/start-local.sh
+++ b/start-local.sh
@@ -457,6 +457,10 @@ choose_es_version() {
     # Get the latest Elasticsearch version
     es_version="$(get_latest_version)"
   fi
+  # Fix for ARM64: add suffix "-arm64"
+  if is_arm64 && [ "${es_version##*-arm64}" = "$es_version" ]; then
+    es_version="${es_version}-arm64"
+  fi
 }
 
 create_env_file() {


### PR DESCRIPTION
This PR fixes the Docker issue for ARM64 adding the suffix `-arm64` to the docker name. 
It solves #43 and replaces #61.