### PR TITLE
Added ES_LOCAL_DIR env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,38 @@ ES_LOCAL_API_KEY=df34grtk...==
 > ./start.sh
 > ```
 
+## ⚠️ Advanced settings with ENV variables
+
+We offer some environment (ENV) variables for changing the settings of `start-local`.
+We suggest to use these ENV variables only for advanced use cases, e.g. CI/CD integrations.
+Please use caution when using these settings.
+
+### ES_LOCAL_PASSWORD
+
+If you need to set the Elasticsearch password manually, you can do it using the `ES_LOCAL_PASSWORD`.
+
+You need to set the env variable before the execution of the script, as follows:
+
+```bash
+curl -fsSL https://elastic.co/start-local | ES_LOCAL_PASSWORD="supersecret" sh
+```
+
+This command will set the `supersecret` password for Elasticsearch.
+
+**Please note** that this command can be dangerous if you use a weak password
+for Elasticsearch authentication.
+
+### ES_LOCAL_DIR
+
+By default, start-local creates an `elastic-start-local` folder. If you need to change it, you can use
+the `ES_LOCAL_DIR` env variable, as follows:
+
+```bash
+curl -fsSL https://elastic.co/start-local | ES_LOCAL_DIR="another-folder" sh
+```
+
+This command will creates the `another-folder` containing all the start-local files.
+
 ## 🧪 Testing the installer
 
 We use [bashunit](https://bashunit.typeddevs.com/) to test the script. Tests are in the `/tests` folder.

--- a/start-local.sh
+++ b/start-local.sh
@@ -88,11 +88,11 @@ startup() {
   # Minimum version for docker-compose
   min_docker_compose="1.29.0"
   # Elasticsearch container name
-  elasticsearch_container_name="es-local-dev-${ES_LOCAL_DIR:-}"
+  elasticsearch_container_name="es-local-dev${ES_LOCAL_DIR:+-${ES_LOCAL_DIR}}"
   # Kibana container name
-  kibana_container_name="kibana-local-dev-${ES_LOCAL_DIR:-}"
-  # Kibana service container name
-  kibana_service_container_name="kibana-settings-${ES_LOCAL_DIR:-}"
+  kibana_container_name="kibana-local-dev${ES_LOCAL_DIR:+-${ES_LOCAL_DIR}}"
+  # Kibana settings container name
+  kibana_settings_container_name="kibana-local-settings${ES_LOCAL_DIR:+-${ES_LOCAL_DIR}}"
   # Minimum disk space required for docker images + services (in GB)
   min_disk_space_required=5
 }
@@ -294,7 +294,7 @@ wait_for_kibana() {
     if [ "$elapsed_time" -ge "$timeout" ]; then
       error_msg="Error: Kibana timeout of ${timeout} sec"
       echo "$error_msg"
-      generate_error_log "${error_msg}" "${elasticsearch_container_name} ${kibana_container_name} kibana_settings"
+      generate_error_log "${error_msg}" "${elasticsearch_container_name} ${kibana_container_name} kibana-settings"
       cleanup
       exit 1
     fi
@@ -433,7 +433,7 @@ check_docker_services() {
   # Check for docker containers running
   check_container_running "$elasticsearch_container_name"
   check_container_running "$kibana_container_name"
-  check_container_running "kibana_settings"
+  check_container_running "$kibana_settings_container_name"
 }
 
 create_installation_folder() {
@@ -482,7 +482,7 @@ EOM
   if  [ -z "${esonly:-}" ]; then
     cat >> .env <<- EOM
 KIBANA_LOCAL_CONTAINER_NAME=$kibana_container_name
-KIBANA_LOCAL_SERVICE_CONTAINER_NAME=$kibana_service_container_name
+KIBANA_LOCAL_SETTINGS_CONTAINER_NAME=$kibana_settings_container_name
 KIBANA_LOCAL_PORT=5601
 KIBANA_LOCAL_PASSWORD=$kibana_password
 KIBANA_ENCRYPTION_KEY=$kibana_encryption_key
@@ -742,7 +742,7 @@ if  [ -z "${esonly:-}" ]; then
       elasticsearch:
         condition: service_healthy
     image: docker.elastic.co/elasticsearch/elasticsearch:${ES_LOCAL_VERSION}
-    container_name: ${KIBANA_LOCAL_SERVICE_CONTAINER_NAME}
+    container_name: ${KIBANA_LOCAL_SETTINGS_CONTAINER_NAME}
     restart: 'no'
     command: >
       bash -c '

--- a/start-local.sh
+++ b/start-local.sh
@@ -88,9 +88,11 @@ startup() {
   # Minimum version for docker-compose
   min_docker_compose="1.29.0"
   # Elasticsearch container name
-  elasticsearch_container_name="es-local-dev"
+  elasticsearch_container_name="es-local-dev-${ES_LOCAL_DIR:-}"
   # Kibana container name
-  kibana_container_name="kibana-local-dev"
+  kibana_container_name="kibana-local-dev-${ES_LOCAL_DIR:-}"
+  # Kibana service container name
+  kibana_service_container_name="kibana-settings-${ES_LOCAL_DIR:-}"
   # Minimum disk space required for docker images + services (in GB)
   min_disk_space_required=5
 }
@@ -480,6 +482,7 @@ EOM
   if  [ -z "${esonly:-}" ]; then
     cat >> .env <<- EOM
 KIBANA_LOCAL_CONTAINER_NAME=$kibana_container_name
+KIBANA_LOCAL_SERVICE_CONTAINER_NAME=$kibana_service_container_name
 KIBANA_LOCAL_PORT=5601
 KIBANA_LOCAL_PASSWORD=$kibana_password
 KIBANA_ENCRYPTION_KEY=$kibana_encryption_key
@@ -739,7 +742,7 @@ if  [ -z "${esonly:-}" ]; then
       elasticsearch:
         condition: service_healthy
     image: docker.elastic.co/elasticsearch/elasticsearch:${ES_LOCAL_VERSION}
-    container_name: kibana_settings
+    container_name: ${KIBANA_LOCAL_SERVICE_CONTAINER_NAME}
     restart: 'no'
     command: >
       bash -c '

--- a/start-local.sh
+++ b/start-local.sh
@@ -80,7 +80,7 @@ startup() {
   version="0.10.0"
 
   # Folder name for the installation
-  installation_folder="elastic-start-local"
+  installation_folder="${ES_LOCAL_DIR:-elastic-start-local}"
   # API key name for Elasticsearch
   api_key_name="elastic-start-local"
   # Name of the error log
@@ -437,9 +437,9 @@ check_docker_services() {
 create_installation_folder() {
   # If $folder already exists, it is empty, see above
   if [ ! -d "$folder" ]; then 
-    mkdir $folder
+    mkdir "$folder"
   fi
-  cd $folder
+  cd "$folder"
   folder_to_clean=$folder
 }
 

--- a/tests/install_with_env_variables.sh
+++ b/tests/install_with_env_variables.sh
@@ -38,3 +38,12 @@ function test_with_es_local_password_env() {
     result=$(get_http_response_code "http://localhost:9200" "elastic" "${password}")
     assert_equals "200" "$result"
 }
+
+function test_with_es_local_dir_env() {
+    dir="test-another-folder"
+    DEFAULT_DIR="${CURRENT_DIR}/${dir}"
+    UNINSTALL_FILE="${DEFAULT_DIR}/uninstall.sh"
+    ES_LOCAL_DIR="${dir}" sh -c "${CURRENT_DIR}/start-local.sh"
+    assert_directory_exists "${DEFAULT_DIR}"
+    assert_file_exists "${UNINSTALL_FILE}"
+}

--- a/tests/start_stop_test.sh
+++ b/tests/start_stop_test.sh
@@ -38,14 +38,14 @@ function tear_down_after_script() {
 function test_stop() {
     "${TEST_DIR}/${DEFAULT_DIR}/stop.sh"
 
-    assert_exit_code "1" "$(check_docker_service_running es-local-dev-)"
-    assert_exit_code "1" "$(check_docker_service_running kibana-local-dev-)"
-    assert_exit_code "1" "$(check_docker_service_running kibana_settings-)"
+    assert_exit_code "1" "$(check_docker_service_running es-local-dev)"
+    assert_exit_code "1" "$(check_docker_service_running kibana-local-dev)"
+    assert_exit_code "1" "$(check_docker_service_running kibana-local-settings)"
 }
 
 function test_start() {
     "${TEST_DIR}/${DEFAULT_DIR}/start.sh"
 
-    assert_exit_code "0" "$(check_docker_service_running es-local-dev-)"
-    assert_exit_code "0" "$(check_docker_service_running kibana-local-dev-)"
+    assert_exit_code "0" "$(check_docker_service_running es-local-dev)"
+    assert_exit_code "0" "$(check_docker_service_running kibana-local-dev)"
 }

--- a/tests/start_stop_test.sh
+++ b/tests/start_stop_test.sh
@@ -38,14 +38,14 @@ function tear_down_after_script() {
 function test_stop() {
     "${TEST_DIR}/${DEFAULT_DIR}/stop.sh"
 
-    assert_exit_code "1" "$(check_docker_service_running es-local-dev)"
-    assert_exit_code "1" "$(check_docker_service_running kibana-local-dev)"
-    assert_exit_code "1" "$(check_docker_service_running kibana_settings)"
+    assert_exit_code "1" "$(check_docker_service_running es-local-dev-)"
+    assert_exit_code "1" "$(check_docker_service_running kibana-local-dev-)"
+    assert_exit_code "1" "$(check_docker_service_running kibana_settings-)"
 }
 
 function test_start() {
     "${TEST_DIR}/${DEFAULT_DIR}/start.sh"
 
-    assert_exit_code "0" "$(check_docker_service_running es-local-dev)"
-    assert_exit_code "0" "$(check_docker_service_running kibana-local-dev)"
+    assert_exit_code "0" "$(check_docker_service_running es-local-dev-)"
+    assert_exit_code "0" "$(check_docker_service_running kibana-local-dev-)"
 }

--- a/tests/uninstall_test.sh
+++ b/tests/uninstall_test.sh
@@ -36,9 +36,9 @@ function tear_down() {
 
 function test_uninstall_outside_installation_folder() {
     printf "yes\nno\n" | "${UNINSTALL_FILE}"
-    assert_exit_code "1" "$(check_docker_service_running es-local-dev)"
-    assert_exit_code "1" "$(check_docker_service_running kibana-local-dev)"
-    assert_exit_code "1" "$(check_docker_service_running kibana_settings)"
+    assert_exit_code "1" "$(check_docker_service_running es-local-dev-)"
+    assert_exit_code "1" "$(check_docker_service_running kibana-local-dev-)"
+    assert_exit_code "1" "$(check_docker_service_running kibana_settings-)"
     assert_is_directory_empty "${TEST_DIR}/${DEFAULT_DIR}"
     assert_exit_code "0" "$(check_docker_image_exists docker.elastic.co/elasticsearch/elasticsearch:"${ES_LOCAL_VERSION}")"
     assert_exit_code "0" "$(check_docker_image_exists docker.elastic.co/kibana/kibana:"${ES_LOCAL_VERSION}")"
@@ -47,9 +47,9 @@ function test_uninstall_outside_installation_folder() {
 function test_uninstall_in_installation_folder() {
     cd "${DEFAULT_DIR}" || exit
     printf "yes\nno\n" | ./uninstall.sh
-    assert_exit_code "1" "$(check_docker_service_running es-local-dev)"
-    assert_exit_code "1" "$(check_docker_service_running kibana-local-dev)"
-    assert_exit_code "1" "$(check_docker_service_running kibana_settings)"
+    assert_exit_code "1" "$(check_docker_service_running es-local-dev-)"
+    assert_exit_code "1" "$(check_docker_service_running kibana-local-dev-)"
+    assert_exit_code "1" "$(check_docker_service_running kibana_settings-)"
     assert_is_directory_empty "${DEFAULT_DIR}"
     assert_exit_code "0" "$(check_docker_image_exists docker.elastic.co/elasticsearch/elasticsearch:"${ES_LOCAL_VERSION}")"
     assert_exit_code "0" "$(check_docker_image_exists docker.elastic.co/kibana/kibana:"${ES_LOCAL_VERSION}")"
@@ -58,9 +58,9 @@ function test_uninstall_in_installation_folder() {
 function test_uninstall_remove_images() {
     cd "${DEFAULT_DIR}" || exit
     printf "yes\nyes\n" | ./uninstall.sh
-    assert_exit_code "1" "$(check_docker_service_running es-local-dev)"
-    assert_exit_code "1" "$(check_docker_service_running kibana-local-dev)"
-    assert_exit_code "1" "$(check_docker_service_running kibana_settings)"
+    assert_exit_code "1" "$(check_docker_service_running es-local-dev-)"
+    assert_exit_code "1" "$(check_docker_service_running kibana-local-dev-)"
+    assert_exit_code "1" "$(check_docker_service_running kibana_settings-)"
     assert_is_directory_empty "${DEFAULT_DIR}"
     assert_exit_code "1" "$(check_docker_image_exists docker.elastic.co/elasticsearch/elasticsearch:"${ES_LOCAL_VERSION}")"
     assert_exit_code "1" "$(check_docker_image_exists docker.elastic.co/kibana/kibana:"${ES_LOCAL_VERSION}")"

--- a/tests/uninstall_test.sh
+++ b/tests/uninstall_test.sh
@@ -36,9 +36,9 @@ function tear_down() {
 
 function test_uninstall_outside_installation_folder() {
     printf "yes\nno\n" | "${UNINSTALL_FILE}"
-    assert_exit_code "1" "$(check_docker_service_running es-local-dev-)"
-    assert_exit_code "1" "$(check_docker_service_running kibana-local-dev-)"
-    assert_exit_code "1" "$(check_docker_service_running kibana_settings-)"
+    assert_exit_code "1" "$(check_docker_service_running es-local-dev)"
+    assert_exit_code "1" "$(check_docker_service_running kibana-local-dev)"
+    assert_exit_code "1" "$(check_docker_service_running kibana-local-settings)"
     assert_is_directory_empty "${TEST_DIR}/${DEFAULT_DIR}"
     assert_exit_code "0" "$(check_docker_image_exists docker.elastic.co/elasticsearch/elasticsearch:"${ES_LOCAL_VERSION}")"
     assert_exit_code "0" "$(check_docker_image_exists docker.elastic.co/kibana/kibana:"${ES_LOCAL_VERSION}")"
@@ -47,9 +47,9 @@ function test_uninstall_outside_installation_folder() {
 function test_uninstall_in_installation_folder() {
     cd "${DEFAULT_DIR}" || exit
     printf "yes\nno\n" | ./uninstall.sh
-    assert_exit_code "1" "$(check_docker_service_running es-local-dev-)"
-    assert_exit_code "1" "$(check_docker_service_running kibana-local-dev-)"
-    assert_exit_code "1" "$(check_docker_service_running kibana_settings-)"
+    assert_exit_code "1" "$(check_docker_service_running es-local-dev)"
+    assert_exit_code "1" "$(check_docker_service_running kibana-local-dev)"
+    assert_exit_code "1" "$(check_docker_service_running kibana-local-settings)"
     assert_is_directory_empty "${DEFAULT_DIR}"
     assert_exit_code "0" "$(check_docker_image_exists docker.elastic.co/elasticsearch/elasticsearch:"${ES_LOCAL_VERSION}")"
     assert_exit_code "0" "$(check_docker_image_exists docker.elastic.co/kibana/kibana:"${ES_LOCAL_VERSION}")"
@@ -58,9 +58,9 @@ function test_uninstall_in_installation_folder() {
 function test_uninstall_remove_images() {
     cd "${DEFAULT_DIR}" || exit
     printf "yes\nyes\n" | ./uninstall.sh
-    assert_exit_code "1" "$(check_docker_service_running es-local-dev-)"
-    assert_exit_code "1" "$(check_docker_service_running kibana-local-dev-)"
-    assert_exit_code "1" "$(check_docker_service_running kibana_settings-)"
+    assert_exit_code "1" "$(check_docker_service_running es-local-dev)"
+    assert_exit_code "1" "$(check_docker_service_running kibana-local-dev)"
+    assert_exit_code "1" "$(check_docker_service_running kibana-local-settings)"
     assert_is_directory_empty "${DEFAULT_DIR}"
     assert_exit_code "1" "$(check_docker_image_exists docker.elastic.co/elasticsearch/elasticsearch:"${ES_LOCAL_VERSION}")"
     assert_exit_code "1" "$(check_docker_image_exists docker.elastic.co/kibana/kibana:"${ES_LOCAL_VERSION}")"


### PR DESCRIPTION
This PR adds the `ES_LOCAL_DIR` environment variable to change the installation folder name (default is `elastic-start-local`).
You can specify this ENV variable as follows:
```bash
curl -fsSL https://elastic.co/start-local | ES_LOCAL_DIR="myfolder" sh
```
This PR implements the request in https://github.com/elastic/start-local/issues/62.