### PR TITLE
Add the EDOT collector service

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ curl -fsSL https://elastic.co/start-local | sh -s -- --esonly
 
 This command can be useful if you don't have enough resources and want to test only Elasticsearch.
 
-### Install the Elastic Distribution of OpenTelemetry (EDOT) Collector 
+### Install the Elastic Distribution of OpenTelemetry (EDOT) Collector
 
 You can install the [EDOT Collector](https://www.elastic.co/docs/reference/opentelemetry/edot-collector)
 using the `--edot` option, as follows:
 
 ```bash
-curl -fsSL https://elastic.co/start-local | sh -s -- --esonly
+curl -fsSL https://elastic.co/start-local | sh -s -- --edot
 ```
 
 This command will install the latest Elasticsearch, Kibana and EDOT collector.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,20 @@ curl -fsSL https://elastic.co/start-local | sh -s -- --esonly
 
 This command can be useful if you don't have enough resources and want to test only Elasticsearch.
 
+### Install the Elastic Distribution of OpenTelemetry (EDOT) Collector 
+
+You can install the [EDOT Collector](https://www.elastic.co/docs/reference/opentelemetry/edot-collector)
+using the `--edot` option, as follows:
+
+```bash
+curl -fsSL https://elastic.co/start-local | sh -s -- --esonly
+```
+
+This command will install the latest Elasticsearch, Kibana and EDOT collector.
+
+[Here](https://www.elastic.co/docs/reference/opentelemetry) you can find more information about
+Elastic Distributions of OpenTelemetry (EDOT).
+
 ### 🌐 Endpoints
 
 After running the script:

--- a/start-local.sh
+++ b/start-local.sh
@@ -23,6 +23,9 @@
 set -eu
 
 parse_args() {
+  #parameters
+  esonly=false
+  otel=false
   # Parse the script parameters
   while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -38,6 +41,11 @@ parse_args() {
 
       --esonly)
         esonly=true
+        shift
+        ;;
+
+      --otel)
+        otel=true
         shift
         ;;
 
@@ -59,6 +67,11 @@ parse_args() {
         ;;
     esac
   done
+  # Verify parameter consistency
+  if [ "$esonly" = "true" ] && [ "$otel" = "true" ]; then
+    echo "Error: the --otel parameter requires also Kibana, you cannot use --esonly"
+    exit 1
+  fi
 }
 
 startup() {
@@ -77,7 +90,7 @@ startup() {
   echo
 
   # Version
-  version="0.10.0"
+  version="0.11.0"
 
   # Folder name for the installation
   installation_folder="${ES_LOCAL_DIR:-elastic-start-local}"
@@ -93,6 +106,8 @@ startup() {
   kibana_container_name="kibana-local-dev${ES_LOCAL_DIR:+-${ES_LOCAL_DIR}}"
   # Kibana settings container name
   kibana_settings_container_name="kibana-local-settings${ES_LOCAL_DIR:+-${ES_LOCAL_DIR}}"
+  # OTEL container name
+  otel_container_name="otel-collector${ES_LOCAL_DIR:+-${ES_LOCAL_DIR}}"
   # Minimum disk space required for docker images + services (in GB)
   min_disk_space_required=5
 }
@@ -244,6 +259,13 @@ generate_error_log() {
     echo "Start-local version: ${version}"
     echo "Docker engine: $(docker --version)"
     echo "Docker compose: ${docker_version}"
+    echo "Elastic Stack version: ${es_version}"
+    if [ "$esonly" = "true" ]; then
+      echo "--esonly parameter used"
+    fi
+    if [ "$otel" = "true" ]; then
+      echo "--otel parameter used"
+    fi
     get_os_info
   } >> "$error_file" 
   for service in $docker_services; do
@@ -294,7 +316,11 @@ wait_for_kibana() {
     if [ "$elapsed_time" -ge "$timeout" ]; then
       error_msg="Error: Kibana timeout of ${timeout} sec"
       echo "$error_msg"
-      generate_error_log "${error_msg}" "${elasticsearch_container_name} ${kibana_container_name} kibana-settings"
+      if [ "$otel" = "true" ]; then
+        generate_error_log "${error_msg}" "${elasticsearch_container_name} ${kibana_container_name} ${kibana_settings_container_name} ${otel_container_name}"
+      else
+        generate_error_log "${error_msg}" "${elasticsearch_container_name} ${kibana_container_name} ${kibana_settings_container_name}"
+      fi
       cleanup
       exit 1
     fi
@@ -434,6 +460,7 @@ check_docker_services() {
   check_container_running "$elasticsearch_container_name"
   check_container_running "$kibana_container_name"
   check_container_running "$kibana_settings_container_name"
+  check_container_running "$otel_container_name"
 }
 
 create_installation_folder() {
@@ -448,7 +475,7 @@ create_installation_folder() {
 generate_passwords() {
   # Generate random passwords
   es_password="${ES_LOCAL_PASSWORD:-$(random_password)}"
-  if  [ -z "${esonly:-}" ]; then
+  if  [ "$esonly" = "false" ]; then
     kibana_password="$(random_password)"
     kibana_encryption_key="$(random_password 32)"
   fi
@@ -474,12 +501,21 @@ ES_LOCAL_CONTAINER_NAME=$elasticsearch_container_name
 ES_LOCAL_PASSWORD=$es_password
 ES_LOCAL_PORT=9200
 ES_LOCAL_URL=http://localhost:\${ES_LOCAL_PORT}
-ES_LOCAL_HEAP_INIT=128m
-ES_LOCAL_HEAP_MAX=2g
 ES_LOCAL_DISK_SPACE_REQUIRED=1gb
 EOM
 
-  if  [ -z "${esonly:-}" ]; then
+  if [ "$otel" = "true" ]; then
+    cat >> .env <<- EOM
+ES_LOCAL_JAVA_OPTS="-Xms2g -Xmx2g"
+OTEL_LOCAL_CONTAINER_NAME=$otel_container_name
+EOM
+  else
+    cat >> .env <<- EOM
+ES_LOCAL_JAVA_OPTS="-Xms128m -Xmx2g"
+EOM
+  fi
+
+  if [ "$esonly" = "false" ]; then
     cat >> .env <<- EOM
 KIBANA_LOCAL_CONTAINER_NAME=$kibana_container_name
 KIBANA_LOCAL_SETTINGS_CONTAINER_NAME=$kibana_settings_container_name
@@ -648,9 +684,15 @@ EOM
   echo "- docker.elastic.co/elasticsearch/elasticsearch:${es_version}"
 EOM
 
-  if  [ -z "${esonly:-}" ]; then
+  if  [ "$esonly" = "false" ]; then
     cat >> uninstall.sh <<- EOM
   echo "- docker.elastic.co/kibana/kibana:${es_version}"
+EOM
+  fi
+
+  if  [ "$otel" = "true" ]; then
+    cat >> uninstall.sh <<- EOM
+  echo "- docker.elastic.co/elastic-agent/elastic-otel-collector:${es_version}"
 EOM
   fi
 
@@ -663,12 +705,22 @@ EOM
     fi
 EOM
 
-  if  [ -z "${esonly:-}" ]; then
+  if  [ "$esonly" = "false" ]; then
     cat >> uninstall.sh <<- EOM
     if docker rmi docker.elastic.co/kibana/kibana:${es_version} >/dev/null 2>&1; then
       echo "Image docker.elastic.co/kibana/kibana:${es_version} removed successfully"
     else
       echo "Failed to remove image docker.elastic.co/kibana/kibana:${es_version}. It might be in use."
+    fi
+EOM
+  fi
+
+  if  [ "$otel" = "true" ]; then
+    cat >> uninstall.sh <<- EOM
+    if docker rmi docker.elastic.co/elastic-agent/elastic-otel-collector:${es_version} >/dev/null 2>&1; then
+      echo "Image docker.elastic.co/elastic-agent/elastic-otel-collector:${es_version} removed successfully"
+    else
+      echo "Failed to remove image docker.elastic.co/elastic-agent/elastic-otel-collector:${es_version}. It might be in use."
     fi
 EOM
   fi
@@ -681,9 +733,98 @@ EOM
   chmod +x uninstall.sh
 }
 
+add_otel_config_in_docker_compose() {
+  # Add the OTLP configs in docker-compose.yml
+  cat >> docker-compose.yml <<-'EOM'
+configs:
+  # This is the minimal yaml configuration needed to listen on all interfaces
+  # for OTLP logs, metrics and traces, exporting to Elasticsearch.
+  edot-collector-config:
+    content: |
+      receivers:
+        otlp:
+          protocols:
+            grpc:
+              endpoint: 0.0.0.0:4317
+            http:
+              endpoint: 0.0.0.0:4318
+      
+      connectors:
+        elasticapm:
+      
+      processors:
+        elastictrace:
+      
+      exporters:
+        elasticsearch:
+          endpoint: http://elasticsearch:9200
+          user: elastic
+          password: ${ES_LOCAL_PASSWORD}
+          mapping:
+            mode: otel
+          logs_dynamic_index:
+            enabled: true
+          metrics_dynamic_index:
+            enabled: true
+          traces_dynamic_index:
+            enabled: true
+          flush:
+            interval: 1s  # improve responsiveness in example apps (default 30s)
+      
+      service:
+        pipelines:
+          traces:
+            receivers: [otlp]
+            processors: [elastictrace]
+            exporters: [elasticapm, elasticsearch]
+      
+          metrics:
+            receivers: [otlp]
+            processors: []
+            exporters: [elasticsearch]
+      
+          metrics/aggregated:
+            receivers: [elasticapm]
+            processors: []
+            exporters: [elasticsearch]
+      
+          logs:
+            receivers: [otlp]
+            processors: []
+            exporters: [elasticapm, elasticsearch]
+EOM
+}
+
+add_otel_service_in_docker_composer() {
+  cat >> docker-compose.yml <<-'EOM'
+  otel-collector:
+    image: docker.elastic.co/elastic-agent/elastic-otel-collector:${ES_LOCAL_VERSION}
+    container_name: ${OTEL_LOCAL_CONTAINER_NAME}
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    command: [
+      "--config=/etc/otelcol-contrib/config.yaml",
+    ]
+    configs:
+      - source: edot-collector-config
+        target: /etc/otelcol-contrib/config.yaml
+    ports:
+      - "4317:4317"  # grpc
+      - "4318:4318"  # http
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c 'echo -n > /dev/tcp/127.0.0.1/4317'"]
+      retries: 300
+      interval: 1s  
+EOM
+}
+
 create_docker_compose_file() {
-  # Create the docker-compose-yml file
-  cat > docker-compose.yml <<-'EOM'
+  # Create the docker-compose.yml file
+  if [ "$otel" = "true" ]; then
+    add_otel_config_in_docker_compose
+  fi
+  cat >> docker-compose.yml <<-'EOM'
 services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:${ES_LOCAL_VERSION}
@@ -699,7 +840,7 @@ services:
       - xpack.security.http.ssl.enabled=false
       - xpack.license.self_generated.type=trial
       - xpack.ml.use_auto_machine_memory_percent=true
-      - ES_JAVA_OPTS=-Xms${ES_LOCAL_HEAP_INIT} -Xmx${ES_LOCAL_HEAP_MAX}
+      - ES_JAVA_OPTS=${ES_LOCAL_JAVA_OPTS}
       - cluster.routing.allocation.disk.watermark.low=${ES_LOCAL_DISK_SPACE_REQUIRED}
       - cluster.routing.allocation.disk.watermark.high=${ES_LOCAL_DISK_SPACE_REQUIRED}
       - cluster.routing.allocation.disk.watermark.flood_stage=${ES_LOCAL_DISK_SPACE_REQUIRED}
@@ -735,7 +876,7 @@ EOM
 
 EOM
 
-if  [ -z "${esonly:-}" ]; then
+if  [ "$esonly" = "false" ]; then
   cat >> docker-compose.yml <<-'EOM'
   kibana_settings:
     depends_on:
@@ -776,6 +917,15 @@ if  [ -z "${esonly:-}" ]; then
       - ELASTICSEARCH_PASSWORD=${KIBANA_LOCAL_PASSWORD}
       - XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY=${KIBANA_ENCRYPTION_KEY}
       - ELASTICSEARCH_PUBLICBASEURL=http://localhost:${ES_LOCAL_PORT}
+EOM
+
+if [ "$otel" = "true" ]; then
+  cat >> docker-compose.yml <<-'EOM'
+      - MONITORING_UI_CONTAINER_ELASTICSEARCH_ENABLED=true
+EOM
+fi
+
+  cat >> docker-compose.yml <<-'EOM'
     healthcheck:
       test:
         [
@@ -789,12 +939,16 @@ if  [ -z "${esonly:-}" ]; then
 EOM
 fi
 
+if [ "$otel" = "true" ]; then
+  add_otel_service_in_docker_composer
+fi
+
   cat >> docker-compose.yml <<-'EOM'
 volumes:
   dev-elasticsearch:
 EOM
 
-if  [ -z "${esonly:-}" ]; then
+if  [ "$esonly" = "false" ]; then
   cat >> docker-compose.yml <<-'EOM'
   dev-kibana:
 EOM
@@ -815,10 +969,12 @@ EOM
 }
 
 print_steps() {
-  if  [ -z "${esonly:-}" ]; then
-    echo "⌛️ Setting up Elasticsearch and Kibana v${es_version}..."
-  else
+  if  [ "$esonly" = "true" ]; then
     echo "⌛️ Setting up Elasticsearch v${es_version}..."
+  elif [ "$otel" = "true" ]; then
+    echo "⌛️ Setting up Elasticsearch, Kibana and OTEL collector v${es_version}..."
+  else
+    echo "⌛️ Setting up Elasticsearch and Kibana v${es_version}..."
   fi
   echo
   echo "- Generated random passwords"
@@ -836,10 +992,12 @@ running_docker_compose() {
   if ! $docker; then
     error_msg="Error: ${docker} command failed!"
     echo "$error_msg"
-    if  [ -z "${esonly:-}" ]; then
-      generate_error_log "${error_msg}" "${elasticsearch_container_name} ${kibana_container_name} kibana_settings"
-    else
+    if [ "$esonly" = "true" ]; then
       generate_error_log "${error_msg}" "${elasticsearch_container_name}"
+    elif [ "$otel" = "true" ]; then
+      generate_error_log "${error_msg}" "${elasticsearch_container_name} ${kibana_container_name} ${kibana_settings_container_name} ${otel_container_name}"
+    else
+      generate_error_log "${error_msg}" "${elasticsearch_container_name} ${kibana_container_name} ${kibana_settings_container_name}"
     fi
     cleanup
     exit 1
@@ -863,18 +1021,22 @@ kibana_wait() {
 
 success() {
   echo
-  if  [ -z "${esonly:-}" ]; then
-    echo "🎉 Congrats, Elasticsearch and Kibana are installed and running in Docker!"
+  if  [ "$esonly" = "true" ]; then
+    echo "🎉 Congrats, Elasticsearch is installed and running in Docker!"
+  else
+    if [ "$otel" = "true" ]; then
+      echo "🎉 Congrats, Elasticsearch, Kibana and OTEL collector are installed and running in Docker!"
+    else
+      echo "🎉 Congrats, Elasticsearch and Kibana are installed and running in Docker!"
+    fi
     echo
     echo "🌐 Open your browser at http://localhost:5601"
     echo
     echo "   Username: elastic"
     echo "   Password: ${es_password}"
     echo
-  else
-    echo "🎉 Congrats, Elasticsearch is installed and running in Docker!"
   fi
-  
+
   echo "🔌 Elasticsearch API endpoint: http://localhost:9200"
   if [ -n "$api_key" ]; then
     echo "🔑 API key: $api_key"

--- a/tests/install_edot_test.sh
+++ b/tests/install_edot_test.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+CURRENT_DIR=$(pwd)
+DEFAULT_DIR="${CURRENT_DIR}/elastic-start-local"
+ENV_PATH="${DEFAULT_DIR}/.env"
+UNINSTALL_FILE="${DEFAULT_DIR}/uninstall.sh"
+
+# include external scripts
+source "${CURRENT_DIR}/tests/utility.sh"
+
+function set_up_before_script() {
+    sh "${CURRENT_DIR}/start-local.sh" "--edot"
+}
+
+function tear_down_after_script() {
+    printf "yes\nno\n" | "${UNINSTALL_FILE}"
+    rm -rf "${DEFAULT_DIR}"
+}
+
+function test_edot_collector_is_running() {
+    result=$(curl -X POST http://localhost:4318/v1/logs \
+  -H "Content-Type: application/json" \
+  -d '{
+    "Timestamp": "1634630400000",
+    "ObservedTimestamp": "1634630401000",
+    "TraceId": "abcd1234",
+    "SpanId": "efgh5678",
+    "SeverityText": "DEBUG",
+    "SeverityNumber": "5",
+    "Body": "Testing log to assert collector OTLP endpoint",
+    "Resource": {
+      "service.name": "start-local-testing"
+    },
+    "InstrumentationScope": {},
+    "Attributes": {}
+  }' \
+  -o /dev/null -s -w "%{http_code}\n")
+
+    assert_equals "200" "$result"
+}
+

--- a/tests/install_edot_test.sh
+++ b/tests/install_edot_test.sh
@@ -18,7 +18,6 @@
 
 CURRENT_DIR=$(pwd)
 DEFAULT_DIR="${CURRENT_DIR}/elastic-start-local"
-ENV_PATH="${DEFAULT_DIR}/.env"
 UNINSTALL_FILE="${DEFAULT_DIR}/uninstall.sh"
 
 # include external scripts


### PR DESCRIPTION
This PR add the EDOT (Elastic Distribution of OpenTelemetry)  collector in start-local using the option `--edot`. This is done using the `edot_collector` configuration reported [here](https://github.com/elastic/elastic-agent/blob/main/internal/pkg/otel/samples/linux/gateway.yml).
This PR should address the request in https://github.com/elastic/start-local/issues/55.

To test the `--edot` option we can run the following command:
```bash
curl -fsSL https://raw.githubusercontent.com/elastic/start-local/refs/heads/feature/otel/start-local.sh | sh -s -- --edot
```

To be done:
- [x] test the EDOT collector in `tests`
- [x] document the `--edot` option in `README.md`