### PR TITLE
Add the xpack.spaces.defaultSolution for Kibana

### DIFF
--- a/start-local.sh
+++ b/start-local.sh
@@ -924,9 +924,15 @@ if  [ "$esonly" = "false" ]; then
       - ELASTICSEARCH_PUBLICBASEURL=http://localhost:${ES_LOCAL_PORT}
 EOM
 
+# Customize the default solution for spaces
 if [ "$edot" = "true" ]; then
   cat >> docker-compose.yml <<-'EOM'
       - MONITORING_UI_CONTAINER_ELASTICSEARCH_ENABLED=true
+      - XPACK_SPACES_DEFAULTSOLUTION=oblt
+EOM
+else
+  cat >> docker-compose.yml <<-'EOM'
+      - XPACK_SPACES_DEFAULTSOLUTION=es
 EOM
 fi
 


### PR DESCRIPTION
This PR adds the support of the `xpack.spaces.defaultSolution` configuration for Kibana (see https://github.com/elastic/kibana/pull/236570).

The proposal is to have the default spaces to Elasticsearch page (`es`) and the Observability page (`oblt`) when specifing `--edot` parameter in start-local.

This should fix #74