### PR TITLE
start-local-podman: Fix loading .env in success()

### DIFF
--- a/start-local-podman.sh
+++ b/start-local-podman.sh
@@ -1534,7 +1534,7 @@ success() {
   fi
 
   # Load ES_LOCAL_API_KEY environment variable.
-  . "$installation_folder/.env"
+  . ./.env
 
   if [ -n "$ES_LOCAL_API_KEY" ]; then
     echo "🔑 API key: $ES_LOCAL_API_KEY"


### PR DESCRIPTION
`create_installation_folder()` will `cd` to the data directory for the duration of the script, so `.env` is actually in the cwd.

---

This fixes:
```
❯ curl -fsSL https://elastic.co/start-local-podman | ES_LOCAL_DIR=data-9.3.2 ES_LOCAL_PASSWORD="changeme" sh -s -- -v 9.3.2       

  ______ _           _   _      
 |  ____| |         | | (_)     
 | |__  | | __ _ ___| |_ _  ___ 
 |  __| | |/ _` / __| __| |/ __|
 | |____| | (_| \__ \ |_| | (__ 
 |______|_|\__,_|___/\__|_|\___|
-------------------------------------------------
🚀 Run Elasticsearch and Kibana for local testing
-------------------------------------------------

ℹ  Do not use this script in a production environment

⌛ Setting up Elasticsearch and Kibana v9.3.2...

- Generated random passwords
- Created the data-9.3.2 folder containing the files:
  - .env, with settings
  - configuration files for Kibana and EDOT (if selected)
  - start/stop/uninstall commands
- Initializing and starting containers...

Creating network 'es-local-dev-net-data-9.3.2' ... done (created).
Creating container 'es-local-dev-data-9.3.2' from image 'docker.elastic.co/elasticsearch/elasticsearch:9.3.2' ... done (created).
Creating container 'kibana-local-dev-data-9.3.2' from image 'docker.elastic.co/kibana/kibana:9.3.2' ... done (created).
Starting container 'es-local-dev-data-9.3.2' ... done.
Waiting for 'es-local-dev-data-9.3.2' ... healthy.
Creating Elasticsearch API key ... done.
Setting up 'kibana_system' user password ... done.
Starting container 'kibana-local-dev-data-9.3.2' ... done.
Waiting for 'kibana-local-dev-data-9.3.2' ... healthy.

🎉 Congrats, Elasticsearch and Kibana are installed and running!

🌐 Open your browser at http://localhost:5601

   Username: elastic
   Password: changeme

🔌 Elasticsearch API endpoint: http://localhost:9200
sh: line 1537: data-9.3.2/.env: No such file or directory
```