### PR TITLE
fix: add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,10 @@ on: # yamllint disable-line rule:truthy
       - 'README.md'
       - '.editorconfig'
 
+permissions:
+  checks: write
+  pull-requests: read
+
 jobs:
   shellcheck:
     name: ShellCheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Install bashunit
       run: |
-        curl -s https://bashunit.typeddevs.com/install.sh | bash
+        curl -sL https://bashunit.typeddevs.com/install.sh | bash
 
     - name: Run the common tests
       env:
@@ -61,7 +61,7 @@ jobs:
 
     - name: Install bashunit
       run: |
-        curl -s https://bashunit.typeddevs.com/install.sh | bash
+        curl -sL https://bashunit.typeddevs.com/install.sh | bash
    
     - name: Set up Podman
       run: |


### PR DESCRIPTION
InfoSec is changing GITHUB_TOKEN default permissions from read/write to read-only on July 15th. Adding explicit permissions blocks to all workflows that require write access.