### PR TITLE
start-local-podman: Fix creation of edot-collector config

### DIFF
--- a/start-local-podman.sh
+++ b/start-local-podman.sh
@@ -209,7 +209,7 @@ generate_error_log() {
     echo "${msg}" > "$error_file"
   fi
 
-  { 
+  {
     echo "Start-local version: ${version}"
     echo "$container_cli engine version: $container_runtime_version"
     echo "Elastic Stack version: ${es_version}"
@@ -244,7 +244,7 @@ startup() {
   echo '-------------------------------------------------'
   echo '🚀 Run Elasticsearch and Kibana for local testing'
   echo '-------------------------------------------------'
-  echo 
+  echo
   echo 'ℹ️  Do not use this script in a production environment'
   echo
 
@@ -437,7 +437,7 @@ check_container_services() {
 }
 
 create_installation_folder() {
-  if [ ! -d "$folder" ]; then 
+  if [ ! -d "$folder" ]; then
     mkdir "$folder"
   fi
   cd "$folder"
@@ -515,7 +515,7 @@ create_kibana_config() {
   if [ "$esonly" = "true" ]; then
     return 0
   fi
-   
+
   if [ ! -d "config" ]; then
     mkdir config
   fi
@@ -532,8 +532,8 @@ create_edot_config() {
     return 0
   fi
 
-  if [ ! -d "$installation_folder/config/edot-collector" ]; then
-    mkdir -p "$installation_folder/config/edot-collector"
+  if [ ! -d config/edot-collector ]; then
+    mkdir -p config/edot-collector
   fi
 
   trace_processor_name="elasticapm"
@@ -544,7 +544,7 @@ create_edot_config() {
   es_local_api_key_var='${ES_LOCAL_API_KEY}'
   # shellcheck disable=SC2016
   es_local_password_var='${ES_LOCAL_PASSWORD}'
-  cat > "$installation_folder/config/edot-collector/config.yaml" <<EOM
+  cat > config/edot-collector/config.yaml <<EOM
 extensions:
   apmconfig:
     source:
@@ -662,7 +662,7 @@ detect_lxc() {
   fi
 
   # Check for LXC in /sys/fs/cgroup
-  if grep -q "lxc" /sys/fs/cgroup/* 2>/dev/null; then  
+  if grep -q "lxc" /sys/fs/cgroup/* 2>/dev/null; then
     return 0
   fi
 
@@ -1044,7 +1044,7 @@ check_license() {
     if [ "$status" = "200" ]; then
       echo "✅ Basic license successfully installed"
       echo "ES_LOCAL_LICENSE=basic" >> .env
-    else 
+    else
       echo "Error: Failed to activate Basic license (HTTP status code $status)."
       exit 1
     fi


### PR DESCRIPTION
`create_installation_folder()` will cd to the data directory for the duration of the script, so the parent directory was getting created twice.

---

This fixes:

```
❯ curl -fsSL https://elastic.co/start-local-podman | ES_LOCAL_DIR=local-dev ES_LOCAL_PASSWORD="changeme" sh -s --  --edot

  ______ _           _   _      
 |  ____| |         | | (_)     
 | |__  | | __ _ ___| |_ _  ___ 
 |  __| | |/ _` / __| __| |/ __|
 | |____| | (_| \__ \ |_| | (__ 
 |______|_|\__,_|___/\__|_|\___|
-------------------------------------------------
🚀 Run Elasticsearch and Kibana for local testing
-------------------------------------------------

ℹ  Do not use this script in a production environment

⌛ Setting up Elasticsearch, Kibana and EDOT collector v9.4.3...

- Generated random passwords
- Created the local-dev folder containing the files:
  - .env, with settings
  - configuration files for Kibana and EDOT (if selected)
  - start/stop/uninstall commands
- Initializing and starting containers...

Creating network 'es-local-dev-net-local-dev' ... done (created).
Creating container 'es-local-dev-local-dev' from image 'docker.elastic.co/elasticsearch/elasticsearch:9.4.3' ... done (created).
Creating container 'kibana-local-dev-local-dev' from image 'docker.elastic.co/kibana/kibana:9.4.3' ... done (created).
Creating container 'edot-collector-local-dev' from image 'docker.elastic.co/elastic-agent/elastic-otel-collector:9.4.3' ... failed.
Trying to pull docker.elastic.co/elastic-agent/elastic-otel-collector:9.4.3...
Getting image source signatures
Copying blob sha256:6008fa439c531d6b2638fc4be980ddfe584a3fa8df53e07ea1836513f2195b2f
Copying blob sha256:cfce329e54e8ce4489296b7c97104d4577be90d04321b22f85a1c0eefd5d2ccb
Copying blob sha256:32e11d18a6cbc040ad3241628af163db4c3a0893a1273b2101034f9959f3c1fc
Copying blob sha256:6f2a9cb60dbaa87e125698d3d96a614e714590a8d77a715a1946901c14976ba8
Copying blob sha256:2850870a7f6cdd952e3ca7a746b9e7dd6ad0ebd13c24a9778b84adaad2df8c34
Copying blob sha256:d16bd660d5aff2d8cb434aefeedc41e2a96fcbfce0e10b612181d05ae773b985
Copying blob sha256:ebb0b2b4d35dc868fb71edbe633ac49adbf2d1b456d8e8e7d63584ebb9bdd729
Copying blob sha256:0a8053e872ec15969f529160231149b75f9abf6f9314f39801399a472cf8df8d
Copying blob sha256:2390072155982ee676c5d935818b8e349a38a61c5a6cad2c02555679ea44b037
Copying blob sha256:7fc0f350edb4e16a2a32adab859952995f1e3b0634fcb35aa49c9ed3700be99d
Copying blob sha256:bd9ddc54bea929a22b334e73e026d4136e5b73f5cc29942896c72e4ece69b13d
Copying config sha256:5c5bef13f2420684850d748fb060ab9c231a620c5a08c6e7b44008a6039cb411
Writing manifest to image destination
Error: statfs /home/agunnerson/git/github/srere-cluster-mgmt/local-dev/config/edot-collector/config.yaml: no such file or directory
Error: Container initialization failed!
```